### PR TITLE
Fix/PWM update rate

### DIFF
--- a/Philips_212_r5/Philips_212_r5.ino
+++ b/Philips_212_r5/Philips_212_r5.ino
@@ -8,9 +8,6 @@
 // Motor velocity target values for 33RPM and 45RPM. Set by trying values while measuring turntable with a separate tachometer
 const float t_set_33 = 3936;
 const int t_set_45 = 5318;
-// Pitch trim range (+ or -)
-const int trim_amount_33 = t_set_33 * 0.02;
-const int trim_amount_45 = t_set_45 * 0.02;
 // Whether to apply speed trimmer values
 const bool APPLY_TRIM = true;
 // Threshold for end-of-record auto-off photo sensor
@@ -51,6 +48,9 @@ const byte debounce = 10;
 const byte v_photo_avg_count = 20;
 // Threshold v_photo when the tonearm is in the exit groove
 const byte v_photo_threshold = 10;
+// Pitch trim range (+ or -) 2%
+const int trim_amount_33 = t_set_33 * 0.02;
+const int trim_amount_45 = t_set_45 * 0.02;
 
 
 /*

--- a/Philips_212_r5/Philips_212_r5.ino
+++ b/Philips_212_r5/Philips_212_r5.ino
@@ -2,23 +2,23 @@
 #define LEDOFF 6    // "OFF" LED drive output, LOW = on
 #define LED33 5     // "33" LED drive output, LOW = on
 #define LED45 7     // "45" LED drive output, LOW = on
-#define BTNOFF 9    // "OFF" touch button input  
+#define BTNOFF 9    // "OFF" touch button input
 #define BTN33 8     // "33" touch button input
 #define BTN45 10    // "45" touch button input
 #define trimpot_33 A0  // analog input from trim pot to fine tune 33 RPM
 #define trimpot_45 A1   // analog inpit from trim pot to fine tune 45 RPM
-#define OPTO A2         // analog input from auto off photo resistor 
+#define OPTO A2         // analog input from auto off photo resistor
 
 byte stateOFF = LOW;      // current state of LEDOFF output, start LEDOFF low (on) at power up
-byte readingOFF= LOW;    // current reading from BTNOFF input, start BTNOFF low at power up
+byte readingOFF = LOW;   // current reading from BTNOFF input, start BTNOFF low at power up
 byte previousOFF = LOW;   // the previous reading from the BTN input, start low at power up
 
 byte state33 = HIGH;      //start 33 RPM off at power up
-byte reading33 = HIGH;           
-byte previous33 = HIGH;    
+byte reading33 = HIGH;
+byte previous33 = HIGH;
 
 byte state45 = HIGH;      //start 45 RPM off at power up
-byte reading45 = HIGH;           
+byte reading45 = HIGH;
 byte previous45 = HIGH;
 
 int v_trim_45;            //45 RPM fine trim pot value
@@ -34,11 +34,11 @@ int t_set;               //Tach period target value for the currently active RPM
 int t_set_33;            //Tach period target value for 33RPM
 int t_set_45;            //Tach period target value for 45RPM
 int t_err_range;         //sets gain of motor control loop
-int n_PWM;               //PWM motor drive    
+int n_PWM;               //PWM motor drive
 int n_offset;
 volatile unsigned long t_per;
-unsigned long microseconds; 
-    
+unsigned long microseconds;
+
 
 // the following variables are long's because the time, measured in miliseconds,
 // will quickly become a bigger number than can be stored in an int.
@@ -46,7 +46,7 @@ long timeOFF = 0;         // the last time the OFF touch botton changed state
 long time33 = 0;          // the last time the 33 touch botton changed state
 long time45 = 0;          // the last time the 45 touch botton changed state
 long debounce = 10;   // debounce time (ms) can be short because OFF, 33, and 45 states latch until a different button is pressed
-                    
+
 void setup()
 {
   pinMode(BTNOFF, INPUT);  //set up OFF, 33, and 45 buttons
@@ -57,150 +57,152 @@ void setup()
   pinMode(LEDOFF, OUTPUT);
   pinMode(tach_in, INPUT);
   pinMode(PWM_out, OUTPUT);
-  attachInterrupt(0, tachometer, FALLING); // set external interrupt for tachometer period measurment
-  //Serial.begin(115200);   //run when troubleshooting
-  
-  t_set_33 = 24650;         //target period for 33RPM. Set by trying values while measuring turntable with a separate tachometer
-  
-  t_set_45 = 17700;         //target period for 45RPM. Set by trying values while measuring turntable with a separate tachometer
-  
+  attachInterrupt(0, tachometer, FALLING); // set external interrupt for tachometer period measurement
+  //  Serial.begin(115200);   //run when troubleshooting
+
+  t_set_33 = 20070;         //target period for 33RPM. Set by trying values while measuring turntable with a separate tachometer
+
+  t_set_45 = 12700;         //target period for 45RPM. Set by trying values while measuring turntable with a separate tachometer
+
   t_per = 50000;            //start with long per to ensure startup
-  t_err_range = 7000;       //maps to PWM output to set gain. Lower number equals higher gain. Set while watching PWM output on oscilloscope. Set to highest values that does not result in oscillation pulse width.
-  n_offset = 127-43;        // PWM output that drives motor at 33.3 RPM. Measured to get approximately correct output when t_diff is 0
+  t_err_range = 11000;      //maps to PWM output to set gain. Lower number equals higher gain. Set while watching PWM output on oscilloscope. Set to highest values that does not result in oscillation pulse width.
+  n_offset = 127 - 43;      // PWM output that drives motor at 33.3 RPM. Measured to get approximately correct output when t_diff is 0
   trim_offset = 512;        // offset fine adjust readings so mid rotation = 0
-  photo_trip = 800;         // threshold for end-of-record auto-off photo sensor
-                            
+  photo_trip = 600;         // threshold for end-of-record auto-off photo sensor
+
 }
 
 /* switch
- * 
- * Each time the input pin goes from LOW to HIGH (e.g. because of a push-button
- * press), the corrosponding output pin goes low and the other two go high. 
- * Repeated button presses of the same button do nothing. A different button must be pressed to change state.
- * There's a minimum delay between toggles to debounce the circuit (i.e. to ignore
- * noise) 
- *
- * David A. Mellis with modifications by L. Sherman (2/2019) for interlock mechanism
- * 21 November 2006
- */
+
+   Each time the input pin goes from LOW to HIGH (e.g. because of a push-button
+   press), the corrosponding output pin goes low and the other two go high.
+   Repeated button presses of the same button do nothing. A different button must be pressed to change state.
+   There's a minimum delay between toggles to debounce the circuit (i.e. to ignore
+   noise)
+
+   David A. Mellis with modifications by L. Sherman (2/2019) for interlock mechanism
+   21 November 2006
+*/
 
 void loop()
 
-{  
-    
-// trouble-shooting serial print parameters
-//Serial.print(t_per);
-//Serial.print(" ");
-//Serial.print(t_diff);
-//Serial.print(" ");
-//Serial.print(v_trim_33);
-//Serial.print(" ");
-//Serial.print(v_trim_45);
-//Serial.print (" ");
-//Serial.print (t_set);
-//Serial.print (" ");
-//Serial.print (n_PWM);
-//Serial.print (" ");
-//Serial.print (v_photo);
-//Serial.println();
+{
 
-v_trim_45 = analogRead (trimpot_45);
-v_trim_33 = analogRead (trimpot_33);
-v_photo = analogRead (OPTO);
+  // trouble-shooting serial print parameters
+  //Serial.print(t_per);
+  //Serial.print(" ");
+  //Serial.print(t_diff);
+  //Serial.print(" ");
+  //Serial.print(v_trim_33);
+  //Serial.print(" ");
+  //Serial.print(v_trim_45);
+  //Serial.print (" ");
+  //Serial.print (t_set);
+  //Serial.print (" ");
+  //Serial.print (n_PWM);
+  //Serial.print (" ");
+  //Serial.print (v_photo);
+  //Serial.println();
+
+  v_trim_45 = analogRead (trimpot_45);
+  v_trim_33 = analogRead (trimpot_33);
+  v_photo = analogRead (OPTO);
 
   // if the input just went from LOW and HIGH and we've waited long enough
   // to ignore any noise on the circuit, drive the output pin low and the other two outputs high and remember
   // the time
-  
+
   // code for "OFF" button and LED
-  
+
   readingOFF = digitalRead(BTNOFF);
-   if (readingOFF == LOW && millis() - timeOFF > debounce) {
+  if (readingOFF == LOW && millis() - timeOFF > debounce) {
     if (stateOFF == HIGH)
-    {stateOFF = LOW;
+    { stateOFF = LOW;
       state33 = HIGH;     //turn off OFF and 45 LEDS
-      state45 = HIGH;}    //turn off OFF and 33 LEDS
-      
+      state45 = HIGH;
+    }    //turn off OFF and 33 LEDS
+
     else
       stateOFF = LOW;
 
-    timeOFF = millis();     
+    timeOFF = millis();
   }
   digitalWrite(LEDOFF, stateOFF);
   previousOFF = readingOFF;
 
-  
+
   // code for "33 RPM" button and LED
   reading33 = digitalRead(BTN33);
 
   if (reading33 == LOW && millis() - time33 > debounce) {
     if (state33 == HIGH)
-       {stateOFF = HIGH;
+    { stateOFF = HIGH;
       state33 = LOW;
       state45 = HIGH;
-     
-       }
-    else 
+
+    }
+    else
       state33 = LOW;
     time33 = millis();
-         
+
   }
 
- if (state33 == LOW) {
-  t_set = t_set_33 + v_trim_33 - trim_offset;
-  } 
+  if (state33 == LOW) {
+    t_set = t_set_33 + v_trim_33 - trim_offset;
+  }
 
   digitalWrite(LED33, state33);
 
   previous33 = reading33;
-  
-  
+
+
   // code for "45 RPM" button and LED
-reading45 = digitalRead(BTN45);
+  reading45 = digitalRead(BTN45);
 
   if (reading45 == LOW && millis() - time45 > debounce) {
     if (state45 == HIGH)
-       {stateOFF = HIGH;
+    { stateOFF = HIGH;
       state33 = HIGH;
       state45 = LOW;
-     
-      }
-    
-    else 
+
+    }
+
+    else
       state45 = LOW;
     time45 = millis();
-        
+
   }
 
   if (state45 == LOW) {
-  t_set = t_set_45 + v_trim_45 - trim_offset; 
+    t_set = t_set_45 + v_trim_45 - trim_offset;
   }
 
   digitalWrite(LED45, state45);
   previous45 = reading45;
 
-//end of "45 RPM" code
+  //end of "45 RPM" code
 
-if (v_photo > photo_trip) // When the tonearm reaches the record end, the photo resistor is interrupted and the OFF state is set
-{     stateOFF = LOW;     // off state, OFF LED on
-      state33 = HIGH;     // turn off OFF and 45 LEDS
-      state45 = HIGH;}
- 
-// read period from tachometer and control motor
- t_per = constrain(t_per, 5000, 50000);
- t_diff = t_per - t_set;
- n_PWM = map(t_diff, t_err_range, -t_err_range, 255, 0);
- n_PWM = n_PWM - n_offset;
- n_PWM = constrain(n_PWM, 0, 255);
+  if (v_photo > photo_trip) // When the tonearm reaches the record end, the photo resistor is interrupted and the OFF state is set
+  { stateOFF = LOW;     // off state, OFF LED on
+    state33 = HIGH;     // turn off OFF and 45 LEDS
+    state45 = HIGH;
+  }
 
-if (stateOFF == LOW) analogWrite (PWM_out, 0);    //hold motor off during OFF state
-else analogWrite(PWM_out, n_PWM);                 //else drive motor with PWM output
- 
+  // read period from tachometer and control motor
+  t_per = constrain(t_per, 5000, 50000);
+  t_diff = t_per - t_set;
+  n_PWM = map(t_diff, t_err_range, -t_err_range, 255, 0);
+  n_PWM = n_PWM - n_offset;
+  n_PWM = constrain(n_PWM, 0, 255);
+
+  if (stateOFF == LOW) analogWrite (PWM_out, 0);    //hold motor off during OFF state
+  else analogWrite(PWM_out, n_PWM);                 //else drive motor with PWM output
+
 }
 
 //Determine time between pulses from tachometer
-void tachometer() 
-{    
-    t_per = micros() - microseconds;
-microseconds = micros();
+void tachometer()
+{
+  t_per = micros() - microseconds;
+  microseconds = micros();
 }

--- a/Philips_212_r5/Philips_212_r5.ino
+++ b/Philips_212_r5/Philips_212_r5.ino
@@ -5,53 +5,48 @@
  * Constants specific to each GA-212 turntable
  */
 
-// Motor velocity target values for 33RPM and 45RPM. Set by trying values while measuring turntable with a separate tachometer
-const float t_set_33 = 3936;
-const int t_set_45 = 5318;
-// Whether to apply speed trimmer values
-const bool APPLY_TRIM = true;
-// Threshold for end-of-record auto-off photo sensor
-const int photo_trip_min = 800;
-
+// Factor that turns velocity into a number that looks like RPMs. Set by trying values while measuring turntable with a separate tachometer.
+const float VEL_FACTOR = 0.846798789;
+// Threshold for end-of-record auto-off photo sensor. This probably doesn't need to be adjusted...
+const int PHOTO_MIN_VALUE = 800;
 
 /*
  * Constants
  */
 
+// Motor velocity target values for 33RPM and 45RPM
+const float TARGET_VEL_33 = 3333;
+const float TARGET_VEL_45 = 4500;
 // Debug flag
 const bool DEBUG = false;
-// "OFF" LED drive output
+// Whether to apply speed trimmer values
+const bool APPLY_TRIM = true;
+// LED pins
 const byte LEDOFF = 6;
-// "33" LED drive output
 const byte LED33 = 5;
-// "45" LED drive output
 const byte LED45 = 7;
-// "OFF" touch button input
+// Button pins
 const byte BTNOFF = 9;
-// "33" touch button input
 const byte BTN33 = 8;
-// "45" touch button input
 const byte BTN45 = 10;
-// Analog input from trim pot to fine tune 33 RPM
+// 33 & 45 RPM speed trimmer pin
 const byte TRIMPOT_33 = A0;
-// Analog inpit from trim pot to fine tune 45 RPM
 const byte TRIMPOT_45 = A1;
-// Analog input from auto off photo resistor
+// Auto off photo resistor pin
 const byte OPTO = A2;
-// Input pin for tach output from motor
+// Motor tachometer pin
 const byte TACH_IN = 2;
-// PWM drive output to motor
+// PWM motor drive pin
 const byte PWM_OUT = 11;
-// Debounce time (ms) can be short because OFF, 33, and 45 states latch until a different button is pressed
-const byte debounce = 10;
-// Number of v_photo measurements to average
-const byte v_photo_avg_count = 20;
-// Threshold v_photo when the tonearm is in the exit groove
-const byte v_photo_threshold = 10;
+// DEBOUNCE_MS time (ms) can be short because OFF, 33, and 45 states latch until a different button is pressed
+const byte DEBOUNCE_MS = 10;
+// Number of photo measurements to average
+const byte PHOTO_MEASUREMENT_COUNT = 20;
+// Amount that valuePhoto needs to change between two measurements, in order to trigger auto-off
+const byte PHOTO_CHANGE_THRESHOLD = 10;
 // Pitch trim range (+ or -) 2%
-const int trim_amount_33 = t_set_33 * 0.02;
-const int trim_amount_45 = t_set_45 * 0.02;
-
+const int TRIM_AMOUNT_33 = TARGET_VEL_33 * 0.02;
+const int TRIM_AMOUNT_45 = TARGET_VEL_45 * 0.02;
 
 /*
  * Variables
@@ -65,43 +60,45 @@ enum playStateValue {
 };
 playStateValue playState = off;
 // 45 RPM fine trim pot value
-int v_trim_45;
+int valueTrim45;
 // 33 RPM fine trim pot value
-int v_trim_33;
+int valueTrim33;
 // Auto-off photo sensor value
-int v_photo = 0;
+int valuePhoto = 0;
 // Flag to remember whether we're measuring the auto-off photo resistor
-bool photo_measuring = false;
-// Moving average of the v_photo measurement
-movingAvg vPhotoAvg(v_photo_avg_count);
-// Previous v_photo average
-int previous_v_photo_avg = 0;
+bool photoMeasurementIsActive = false;
+// Moving average of the valuePhoto measurement
+movingAvg valuePhotoAvg(PHOTO_MEASUREMENT_COUNT);
+// Previous valuePhoto average
+int previousValuePhotoAvg = 0;
 
 // The following variables are longs because the time, measured in miliseconds,
 // will quickly become a bigger number than can be stored in an int.
 
 // Last time OFF button changed state
-long timeOFF = 0;
+long lastTimeOff = 0;
 // Last time 33 button changed state
-long time33 = 0;
+long lastTime33 = 0;
 // Last time 45 button changed state
-long time45 = 0;
+long lastTime45 = 0;
 // Last time 33 or 45 button changed state
-long timePlay = 0;
-// Last time we started v_photo readings
-long time_photo_start = 0;
+long lastTimePlay = 0;
+// Last time we started valuePhoto readings
+long timePhotoMeasureStart = 0;
 
 // PID
 float pidSetpoint = 0;
 float pidInput;
 float pidOutput = 0;
-const float pidP = 0.12, pidI = 0.6, pidD = 0.00001;
+//const float pidP = 0.12, pidI = 0.6, pidD = 0.00001;
+//const float pidP = 0.27, pidI = 0, pidD = 0;
+const float pidP = 0.135, pidI = 0.8, pidD = 0.00001;
 QuickPID motorPid(&pidInput, &pidOutput, &pidSetpoint);
 
 // Use the "volatile" directive for variables
 // used in an interrupt
-volatile float velocity_i = 0;
-volatile long prevT_i = 0;
+volatile float velocityInterrupt = 0;
+volatile long prevTimeInterrupt = 0;
 
 void setup()
 {
@@ -127,8 +124,8 @@ void setup()
   // Turn PID on
   motorPid.SetMode(motorPid.Control::automatic);
 
-  // Initialise v_photo measurement moving average
-  vPhotoAvg.begin();
+  // Initialise valuePhoto measurement moving average
+  valuePhotoAvg.begin();
 
   if (DEBUG) {
     Serial.begin(115200);
@@ -136,155 +133,178 @@ void setup()
 }
 
 /*
- * Determine time between pulses from tachometer
+ * Interrupt function to determine motor velocity using tachometer pulses
  */
 void tachometer()
 {
   // Compute velocity
-  long currT = micros();
-  float deltaT = ((float) (currT - prevT_i))/1.0e8;
-  velocity_i = 1/deltaT;
-  prevT_i = currT;
+  long currTime = micros();
+  float timeDelta = ((float) (currTime - prevTimeInterrupt))/1.0e8;
+  velocityInterrupt = 1/timeDelta * VEL_FACTOR;
+  prevTimeInterrupt = currTime;
 }
 
-void buttonsAndLeds()
+/*
+ * Main loop
+ */
+void loop()
+{
+  readInputs();
+
+  handleButtonPresses();
+
+  driveLeds();
+
+  autoOff();
+
+  motorControl();
+    
+  debug();
+}
+
+void readInputs()
+{
+  // read the motor velocity
+  noInterrupts(); // disable interrupts temporarily while reading
+  pidInput = velocityInterrupt;
+  interrupts(); // turn interrupts back on
+
+  if (APPLY_TRIM) {
+    valueTrim45 = analogRead(TRIMPOT_45);
+    valueTrim33 = analogRead(TRIMPOT_33);
+  }
+  valuePhoto = analogRead(OPTO);
+}
+
+/*
+ * Get amount to add to setPoint depending on trimmer value
+ */
+float getTrimAmount(bool for33 = true)
+{
+  int trimAmount = for33 ? TRIM_AMOUNT_33 : TRIM_AMOUNT_45;
+  int trimmerValue = for33 ? valueTrim33 : valueTrim45;
+  return trimAmount * map(trimmerValue, 1023, 0, -512, 512) / 512;
+}
+
+void handleButtonPresses()
 {
   /*
-   * "OFF" button and LED
+   * "OFF" button
    */
   // if the input just went from LOW and HIGH and we've waited long enough
   // to ignore any noise on the circuit, drive the output pin low and the other two outputs high and remember
   // the time
-  if (playState != off && digitalRead(BTNOFF) == LOW && millis() - timeOFF > debounce) {
+  if (playState != off && digitalRead(BTNOFF) == LOW && millis() - lastTimeOff > DEBOUNCE_MS) {
     playState = off;
     pidSetpoint = 0;
-    timeOFF = millis();
+    lastTimeOff = millis();
   }
-  digitalWrite(LEDOFF, playState == off ? LOW : HIGH);
 
   /*
-   * "33 RPM" button and LED
+   * "33 RPM" button
    */
-  if (playState != play33 && digitalRead(BTN33) == LOW && millis() - time33 > debounce) {
-    time33 = millis();
+  if (playState != play33 && digitalRead(BTN33) == LOW && millis() - lastTime33 > DEBOUNCE_MS) {
+    lastTime33 = millis();
     if (playState == off) {
-      timePlay = time33;
+      lastTimePlay = lastTime33;
     }
-    pidSetpoint = t_set_33;
+    pidSetpoint = TARGET_VEL_33;
     pidInput = pidSetpoint * 1.5;
     playState = play33;
   } else if (playState == play33 && APPLY_TRIM) {
-    float adjust33 = map(v_trim_33, 1023, 0, -100, 100);
-    pidSetpoint = t_set_33 + (trim_amount_33 * (adjust33 / 100));
+    // We didn't press the button, but we do want to apply trim
+    pidSetpoint = TARGET_VEL_33 + getTrimAmount(true);
   }
-  digitalWrite(LED33, playState == play33 ? LOW : HIGH);
 
   /*
-   * "45 RPM" button and LED
+   * "45 RPM" button
    */
-  if (playState != play45 && digitalRead(BTN45) == LOW && millis() - time45 > debounce) {
-    time45 = millis();
+  if (playState != play45 && digitalRead(BTN45) == LOW && millis() - lastTime45 > DEBOUNCE_MS) {
+    lastTime45 = millis();
     if (playState == off) {
-      timePlay = time45;
+      lastTimePlay = lastTime45;
     }
-    pidSetpoint = t_set_45;
+    pidSetpoint = TARGET_VEL_45;
     pidInput = pidSetpoint * 1.5;
     playState = play45;
   } else if (playState == play45 && APPLY_TRIM) {
-    float adjust45 = map(v_trim_45, 1023, 0, -100, 100);
-    pidSetpoint = t_set_45 + (trim_amount_45 * (adjust45 / 100));
+    // We didn't press the button, but we do want to apply trim
+    pidSetpoint = TARGET_VEL_45 + getTrimAmount(false);
   }
+}
+
+void driveLeds()
+{
+  digitalWrite(LEDOFF, playState == off ? LOW : HIGH);
+  digitalWrite(LED33, playState == play33 ? LOW : HIGH);
   digitalWrite(LED45, playState == play45 ? LOW : HIGH);
 }
 
 void autoOff()
 {
   /*
-   * Tonearm photo trip
+   * Auto-off logic using tone arm photo trip
    *
    * When the tonearm reaches the record end, the photo resistor is interrupted and the OFF state is set.
    */
-  if (playState != off && v_photo > photo_trip_min) {
-    if (photo_measuring == false && millis() - time_photo_start > 200) {
-      // Start a new measurement every 200 ms
-      time_photo_start = millis();
-      photo_measuring = true;
-      vPhotoAvg.reset();
-    }
-    if (photo_measuring) {
-      // Add a reading up to the count
-      if (vPhotoAvg.getCount() < v_photo_avg_count) {
-        vPhotoAvg.reading(v_photo);
-      } else {
-        // We have sufficient readings, stop measuring
-        photo_measuring = false;
-        // Compare measurement, turn off if over threshold
-        if (vPhotoAvg.getAvg() - previous_v_photo_avg > v_photo_threshold) {
-          playState = off;
-        }
-        previous_v_photo_avg = vPhotoAvg.getAvg();
-      }
-    }
+  if (playState == off || valuePhoto < PHOTO_MIN_VALUE) {
+    // Only apply auto-off logic:
+    // - when the turntable is playing.
+    // - when a minimum amount of light is detected by the optical sensor,
+    //   which indicates that the tone arm is close to the end of the record.
+    return;
   }
+  // Start a new measurement every 200 ms
+  if (photoMeasurementIsActive == false && millis() - timePhotoMeasureStart > 200) {
+    timePhotoMeasureStart = millis();
+    valuePhotoAvg.reset();
+    photoMeasurementIsActive = true;
+  }
+  if (!photoMeasurementIsActive) {
+    return;
+  }
+  // Add a reading up to the amount needed
+  if (valuePhotoAvg.getCount() < PHOTO_MEASUREMENT_COUNT) {
+    valuePhotoAvg.reading(valuePhoto);
+    return;
+  }
+  // We have enough readings to average, check if auto-off threshold was triggered.
+  if (valuePhotoAvg.getAvg() - previousValuePhotoAvg > PHOTO_CHANGE_THRESHOLD) {
+    // Turn off...
+    playState = off;
+  }
+  previousValuePhotoAvg = valuePhotoAvg.getAvg();
+  // Stop measuring, we'll start a new measurement next loop...
+  photoMeasurementIsActive = false;
 }
 
-/* switch
-
-   Each time the input pin goes from LOW to HIGH (e.g. because of a push-button
-   press), the corrosponding output pin goes low and the other two go high.
-   Repeated button presses of the same button do nothing. A different button must be pressed to change state.
-   There's a minimum delay between toggles to debounce the circuit (i.e. to ignore
-   noise)
-
-   David A. Mellis with modifications by L. Sherman (2/2019) for interlock mechanism
-   21 November 2006
-*/
-
-void loop()
+void motorControl()
 {
-  // read the velocity
-  noInterrupts(); // disable interrupts temporarily while reading
-  pidInput = velocity_i;
-  interrupts(); // turn interrupts back on
-
-  if (APPLY_TRIM) {
-    v_trim_45 = analogRead(TRIMPOT_45);
-    v_trim_33 = analogRead(TRIMPOT_33);
-  }
-  v_photo = analogRead(OPTO);
-  
-  debug();
-
-  buttonsAndLeds();
-
-  autoOff();
-
   /*
-   * Control motor
-   *
    * Hold motor off during off state, else drive with PWM output
    */
   if (playState == off) {
     analogWrite(PWM_OUT, 0);
-  } else {
-    if (playState != off && millis() - timePlay < 100) {
-      // Give the motor enough power initially to get going
-      analogWrite(PWM_OUT, 250);
-    } else {
-      // We don't need that much power afterwards
-      motorPid.SetOutputLimits(50, 150);
-      motorPid.Compute();
-      analogWrite(PWM_OUT, pidOutput);
-    }
+    return;
   }
+  if (millis() - lastTimePlay < 100) {
+    // Give the motor enough power initially to get going (circumvent PID)
+    analogWrite(PWM_OUT, 250);
+    return;
+  }
+  // We don't need much power afterwards to keep the motor going
+  motorPid.SetOutputLimits(50, 150);
 
+  // Get PID value and apply
+  motorPid.Compute();
+  analogWrite(PWM_OUT, pidOutput);
 }
 
-/*
- * Debug output
- */
 void debug()
 {
+  /*
+   * Debug output
+   */
   if (!DEBUG) {
     return;
   }

--- a/Philips_212_r5/Philips_212_r5.ino
+++ b/Philips_212_r5/Philips_212_r5.ino
@@ -163,7 +163,7 @@ void readInputs()
 {
   // read the motor velocity
   noInterrupts(); // disable interrupts temporarily while reading
-  float tachPeriod = pidInput = velocityAvg.reading(tachPeriodInterrupt);
+  float tachPeriod = velocityAvg.reading(tachPeriodInterrupt);
   interrupts(); // turn interrupts back on
 
   // Compute velocity from tach period

--- a/Philips_212_r5/Philips_212_r5.ino
+++ b/Philips_212_r5/Philips_212_r5.ino
@@ -1,75 +1,140 @@
+#include <movingAvg.h>  // https://github.com/JChristensen/movingAvg
 
-#define LEDOFF 6    // "OFF" LED drive output, LOW = on
-#define LED33 5     // "33" LED drive output, LOW = on
-#define LED45 7     // "45" LED drive output, LOW = on
-#define BTNOFF 9    // "OFF" touch button input
-#define BTN33 8     // "33" touch button input
-#define BTN45 10    // "45" touch button input
-#define trimpot_33 A0  // analog input from trim pot to fine tune 33 RPM
-#define trimpot_45 A1   // analog inpit from trim pot to fine tune 45 RPM
-#define OPTO A2         // analog input from auto off photo resistor
+/*
+ * Constants specific to each GA-212 turntable
+ */
 
-byte stateOFF = LOW;      // current state of LEDOFF output, start LEDOFF low (on) at power up
-byte readingOFF = LOW;   // current reading from BTNOFF input, start BTNOFF low at power up
-byte previousOFF = LOW;   // the previous reading from the BTN input, start low at power up
+// Tach period target value for 33RPM. Set by trying values while measuring turntable with a separate tachometer
+const int t_set_33 = 20070;
+// Tach period target value for 45RPM. Set by trying values while measuring turntable with a separate tachometer
+const int t_set_45 = 12700;
+// Maps to PWM output to set gain. Lower number equals higher gain. Set while watching PWM output on oscilloscope. Set to highest values that does not result in oscillation pulse width.
+const int t_err_range = 11000;
+// Offset fine trim reading so center rotation = 0
+const int trim_offset = 512;
+// Threshold for end-of-record auto-off photo sensor
+const int photo_trip_min = 800;
 
-byte state33 = HIGH;      //start 33 RPM off at power up
-byte reading33 = HIGH;
-byte previous33 = HIGH;
 
-byte state45 = HIGH;      //start 45 RPM off at power up
-byte reading45 = HIGH;
-byte previous45 = HIGH;
+/*
+ * Constants
+ */
 
-int v_trim_45;            //45 RPM fine trim pot value
-int v_trim_33;            //33 RPM fine trim pot value
-int v_photo;               //auto-off photo sensor value
-int photo_trip;             //threshold for auto-off sensing
-int trim_offset;            //offset fine trim reading so center rotation = 0
+// Debug flag
+const bool DEBUG = false;
+// "OFF" LED drive output
+const byte LEDOFF = 6;
+// "33" LED drive output
+const byte LED33 = 5;
+// "45" LED drive output
+const byte LED45 = 7;
+// "OFF" touch button input
+const byte BTNOFF = 9;
+// "33" touch button input
+const byte BTN33 = 8;
+// "45" touch button input
+const byte BTN45 = 10;
+// Analog input from trim pot to fine tune 33 RPM
+const byte TRIMPOT_33 = A0;
+// Analog inpit from trim pot to fine tune 45 RPM
+const byte TRIMPOT_45 = A1;
+// Analog input from auto off photo resistor
+const byte OPTO = A2;
+// Input pin for tach output from motor
+const byte TACH_IN = 2;
+// PWM drive output to motor
+const byte PWM_OUT = 11;
+// PWM output that drives motor at 33.3 RPM. Measured to get approximately correct output when t_diff is 0
+const int n_offset = 127 - 43;
+// Debounce time (ms) can be short because OFF, 33, and 45 states latch until a different button is pressed
+const byte debounce = 10;
+// Number of v_photo measurements to average
+const byte v_photo_avg_count = 20;
+// Threshold v_photo when the tonearm is in the exit groove
+const byte v_photo_threshold = 10;
 
-byte tach_in = 2;         //input pin for tach output from motor
-byte PWM_out = 11;        //PWM drive output to motor
-int t_diff;              //difference between set and target period
-int t_set;               //Tach period target value for the currently active RPM
-int t_set_33;            //Tach period target value for 33RPM
-int t_set_45;            //Tach period target value for 45RPM
-int t_err_range;         //sets gain of motor control loop
-int n_PWM;               //PWM motor drive
-int n_offset;
+
+/*
+ * Variables
+ */
+
+// Play state
+enum playStateValue {
+  off,
+  play33,
+  play45
+};
+playStateValue playState = off;
+// 45 RPM fine trim pot value
+int v_trim_45;
+// 33 RPM fine trim pot value
+int v_trim_33;
+// Auto-off photo sensor value
+int v_photo = 0;
+// Flag to remember whether we're measuring the auto-off photo resistor
+bool photo_measuring = false;
+// Moving average of the v_photo measurement
+movingAvg vPhotoAvg(v_photo_avg_count);
+// Previous v_photo average
+int previous_v_photo_avg = 0;
+
+// Difference between set and target period
+int t_diff;
+// Tach period target value for the currently active RPM
+int t_set;
+// PWM motor drive
+int n_PWM;
 volatile unsigned long t_per;
 unsigned long microseconds;
 
-
-// the following variables are long's because the time, measured in miliseconds,
+// The following variables are longs because the time, measured in miliseconds,
 // will quickly become a bigger number than can be stored in an int.
-long timeOFF = 0;         // the last time the OFF touch botton changed state
-long time33 = 0;          // the last time the 33 touch botton changed state
-long time45 = 0;          // the last time the 45 touch botton changed state
-long debounce = 10;   // debounce time (ms) can be short because OFF, 33, and 45 states latch until a different button is pressed
+
+// Last time OFF button changed state
+long timeOFF = 0;
+// Last time 33 button changed state
+long time33 = 0;
+// Last time 45 button changed state
+long time45 = 0;
+// Last time we started v_photo readings
+long time_photo_start = 0;
+
 
 void setup()
 {
-  pinMode(BTNOFF, INPUT);  //set up OFF, 33, and 45 buttons
+  // Set pins
+  pinMode(BTNOFF, INPUT);
   pinMode(BTN33, INPUT);
   pinMode(BTN45, INPUT);
-  pinMode(LED45, OUTPUT);  //set up OFF, 33, and 45 indicator LEDs
+
+  pinMode(LED45, OUTPUT);
   pinMode(LED33, OUTPUT);
   pinMode(LEDOFF, OUTPUT);
-  pinMode(tach_in, INPUT);
-  pinMode(PWM_out, OUTPUT);
-  attachInterrupt(0, tachometer, FALLING); // set external interrupt for tachometer period measurement
-  //  Serial.begin(115200);   //run when troubleshooting
 
-  t_set_33 = 20070;         //target period for 33RPM. Set by trying values while measuring turntable with a separate tachometer
+  pinMode(TACH_IN, INPUT);
+  pinMode(PWM_OUT, OUTPUT);
 
-  t_set_45 = 12700;         //target period for 45RPM. Set by trying values while measuring turntable with a separate tachometer
+  // Set external interrupt for tachometer period measurement
+  attachInterrupt(digitalPinToInterrupt(TACH_IN), tachometer, FALLING);
 
-  t_per = 50000;            //start with long per to ensure startup
-  t_err_range = 11000;      //maps to PWM output to set gain. Lower number equals higher gain. Set while watching PWM output on oscilloscope. Set to highest values that does not result in oscillation pulse width.
-  n_offset = 127 - 43;      // PWM output that drives motor at 33.3 RPM. Measured to get approximately correct output when t_diff is 0
-  trim_offset = 512;        // offset fine adjust readings so mid rotation = 0
-  photo_trip = 600;         // threshold for end-of-record auto-off photo sensor
+  // Start with long period to ensure startup
+  t_per = 50000;
 
+  // Initialise v_photo measurement moving average
+  vPhotoAvg.begin();
+
+  if (DEBUG) {
+    Serial.begin(115200);
+  }
+}
+
+/*
+ * Determine time between pulses from tachometer
+ */
+void tachometer()
+{
+  t_per = micros() - microseconds;
+  microseconds = micros();
 }
 
 /* switch
@@ -85,124 +150,121 @@ void setup()
 */
 
 void loop()
-
 {
+  debug();
 
-  // trouble-shooting serial print parameters
-  //Serial.print(t_per);
-  //Serial.print(" ");
-  //Serial.print(t_diff);
-  //Serial.print(" ");
-  //Serial.print(v_trim_33);
-  //Serial.print(" ");
-  //Serial.print(v_trim_45);
-  //Serial.print (" ");
-  //Serial.print (t_set);
-  //Serial.print (" ");
-  //Serial.print (n_PWM);
-  //Serial.print (" ");
-  //Serial.print (v_photo);
-  //Serial.println();
+  v_trim_45 = analogRead(TRIMPOT_45);
+  v_trim_33 = analogRead(TRIMPOT_33);
+  v_photo = analogRead(OPTO);
 
-  v_trim_45 = analogRead (trimpot_45);
-  v_trim_33 = analogRead (trimpot_33);
-  v_photo = analogRead (OPTO);
-
+  /*
+   * "OFF" button and LED
+   */
   // if the input just went from LOW and HIGH and we've waited long enough
   // to ignore any noise on the circuit, drive the output pin low and the other two outputs high and remember
   // the time
-
-  // code for "OFF" button and LED
-
-  readingOFF = digitalRead(BTNOFF);
-  if (readingOFF == LOW && millis() - timeOFF > debounce) {
-    if (stateOFF == HIGH)
-    { stateOFF = LOW;
-      state33 = HIGH;     //turn off OFF and 45 LEDS
-      state45 = HIGH;
-    }    //turn off OFF and 33 LEDS
-
-    else
-      stateOFF = LOW;
-
+  if (playState != off && digitalRead(BTNOFF) == LOW && millis() - timeOFF > debounce) {
+    playState = off;
     timeOFF = millis();
   }
-  digitalWrite(LEDOFF, stateOFF);
-  previousOFF = readingOFF;
+  digitalWrite(LEDOFF, playState == off ? LOW : HIGH);
 
-
-  // code for "33 RPM" button and LED
-  reading33 = digitalRead(BTN33);
-
-  if (reading33 == LOW && millis() - time33 > debounce) {
-    if (state33 == HIGH)
-    { stateOFF = HIGH;
-      state33 = LOW;
-      state45 = HIGH;
-
-    }
-    else
-      state33 = LOW;
+  /*
+   * "33 RPM" button and LED
+   */
+  if (playState != play33 && digitalRead(BTN33) == LOW && millis() - time33 > debounce) {
+    playState = play33;
     time33 = millis();
-
   }
-
-  if (state33 == LOW) {
+  if (playState == play33) {
     t_set = t_set_33 + v_trim_33 - trim_offset;
   }
+  digitalWrite(LED33, playState == play33 ? LOW : HIGH);
 
-  digitalWrite(LED33, state33);
-
-  previous33 = reading33;
-
-
-  // code for "45 RPM" button and LED
-  reading45 = digitalRead(BTN45);
-
-  if (reading45 == LOW && millis() - time45 > debounce) {
-    if (state45 == HIGH)
-    { stateOFF = HIGH;
-      state33 = HIGH;
-      state45 = LOW;
-
-    }
-
-    else
-      state45 = LOW;
+  /*
+   * "45 RPM" button and LED
+   */
+  if (playState != play45 && digitalRead(BTN45) == LOW && millis() - time45 > debounce) {
+    playState = play45;
     time45 = millis();
-
   }
-
-  if (state45 == LOW) {
+  if (playState == play45) {
     t_set = t_set_45 + v_trim_45 - trim_offset;
   }
+  digitalWrite(LED45, playState == play45 ? LOW : HIGH);
 
-  digitalWrite(LED45, state45);
-  previous45 = reading45;
-
-  //end of "45 RPM" code
-
-  if (v_photo > photo_trip) // When the tonearm reaches the record end, the photo resistor is interrupted and the OFF state is set
-  { stateOFF = LOW;     // off state, OFF LED on
-    state33 = HIGH;     // turn off OFF and 45 LEDS
-    state45 = HIGH;
+  /*
+   * Tonearm photo trip
+   *
+   * When the tonearm reaches the record end, the photo resistor is interrupted and the OFF state is set.
+   */
+  if (playState != off && v_photo > photo_trip_min) {
+    if (photo_measuring == false && millis() - time_photo_start > 200) {
+      // Start a new measurement every 200 ms
+      time_photo_start = millis();
+      photo_measuring = true;
+      vPhotoAvg.reset();
+    }
+    if (photo_measuring) {
+      // Add a reading up to the count
+      if (vPhotoAvg.getCount() < v_photo_avg_count) {
+        vPhotoAvg.reading(v_photo);
+      } else {
+        // We have sufficient readings, stop measuring
+        photo_measuring = false;
+        // Compare measurement, turn off if over threshold
+        if (vPhotoAvg.getAvg() - previous_v_photo_avg > v_photo_threshold) {
+          playState = off;
+        }
+        previous_v_photo_avg = vPhotoAvg.getAvg();
+      }
+    }
   }
 
-  // read period from tachometer and control motor
+  /*
+   * Read period from tachometer
+   */
   t_per = constrain(t_per, 5000, 50000);
   t_diff = t_per - t_set;
   n_PWM = map(t_diff, t_err_range, -t_err_range, 255, 0);
   n_PWM = n_PWM - n_offset;
   n_PWM = constrain(n_PWM, 0, 255);
 
-  if (stateOFF == LOW) analogWrite (PWM_out, 0);    //hold motor off during OFF state
-  else analogWrite(PWM_out, n_PWM);                 //else drive motor with PWM output
+  /*
+   * Control motor
+   *
+   * Hold motor off during off state, else drive with PWM output
+   */
+  analogWrite (PWM_OUT, playState == off ? 0 : n_PWM);
 
 }
 
-//Determine time between pulses from tachometer
-void tachometer()
+/*
+ * Debug output
+ */
+void debug()
 {
-  t_per = micros() - microseconds;
-  microseconds = micros();
+  if (DEBUG) {
+    Serial.print(t_per);
+    Serial.print(" ");
+    Serial.print(t_diff);
+    Serial.print(" ");
+    Serial.print(v_trim_33);
+    Serial.print(" ");
+    Serial.print(v_trim_45);
+    Serial.print (" ");
+    Serial.print (t_set);
+    Serial.print (" ");
+    Serial.print (n_PWM);
+    Serial.print (" ");
+    Serial.print (v_photo);
+    Serial.print (" ");
+    Serial.print (playState);
+    Serial.print (" ");
+    if (vPhotoAvg.getAvg() - previous_v_photo_avg > 0) {
+      Serial.print (vPhotoAvg.getAvg() - previous_v_photo_avg);
+      Serial.print (" ");
+    }
+    Serial.println();
+  }
 }


### PR DESCRIPTION
The PWM update rate was set too low because of [QuickPID](https://github.com/Dlloydev/QuickPID)'s default compute interval of 100ms (10Hz, ha). This caused the motor to judder because of sudden PWM compensations.

This PR fixes that by setting `motorPid.SetSampleTimeUs(2000);`.

Additional changes:
- Remove tachometer value averaging, it's no longer required
- Increase motor startup time to 1 second, this seems to get it going nicely, close to the desired speed at which point PID can take over.